### PR TITLE
[WIP]: jest watch placeholder

### DIFF
--- a/TODO_JESTWATCH.md
+++ b/TODO_JESTWATCH.md
@@ -1,0 +1,16 @@
+### Watch plugins
+
+- [jest-watch-directories](https://github.com/cameronhunter/jest-watch-directories/tree/master/packages/jest-watch-directories) Select directories to test.
+- [jest-watch-exec](https://github.com/unional/jest-watch-exec) Execute scripts during the watch cycle.
+- [jest-watch-lerna-packages](https://github.com/cameronhunter/jest-watch-directories/blob/master/packages/jest-watch-lerna-packages) Select Lerna packages to test.
+- [jest-watch-master](https://github.com/rickhanlonii/jest-watch-master) Check changes since master.
+- [jest-watch-repeat](https://github.com/unional/jest-watch-repeat) Repeat test runs multiple times.
+- [jest-watch-select-projects](https://github.com/rogeliog/jest-watch-select-projects) Select which Jest projects to run.
+- [jest-watch-suspend](https://github.com/unional/jest-watch-suspend) Suspend watch mode so that your changes would not trigger test runs.
+- [jest-watch-toggle-config](https://github.com/jest-community/jest-watch-toggle-config) Toggle boolean settings (e.g. verbosity, test coverage).
+- [jest-watch-typeahead](https://github.com/jest-community/jest-watch-typeahead) Filter your tests by file name or test name.
+- [jest-watch-yarn-workspaces](https://github.com/cameronhunter/jest-watch-directories/tree/master/packages/jest-watch-yarn-workspaces) Select Yarn workspaces to test.
+- [node-recorder](https://github.com/ericclemmons/node-recorder/#using-jest) Toggle recording modes for `node-recorder`.
+
+
+[Awesome-Jest List](https://github.com/jest-community/awesome-jest/blob/master/README.md#results-processors)


### PR DESCRIPTION
Placeholder for integration with jest watch mode

Considerations

- should run mock service on random ports to avoid clashes
- should only run changed tests when In  watch mode
- we need to exclude the log and pact directories to avoid getting stuck in infinite loops
- write mode is important in the pact options. We need to ensure the following
  - generated pacts should not contain old interactions
  - generated pacts must contain all interactions even if we test the same consumer/provider pair across multiple test files
  - deleting all pacts before a single test run solves that problem but if running in watch mode we can’t delete all pacts, as jest-pact May only run a single changed pact and deleting them all would mean we would be missing pact files ( overwrite seems like the best option when in watch mode, but we need to be careful to ensure all pact interactions are recorded.
  - we can get the name of a test that has failed interaction, and jest watch will rerun a full test file, not just a single test within the file, so we could just delete the associated pact file but need to consider if the user has two tests with the same consumer/provider pair. We don’t want to delete  the pact and only rerun a single test as we will lose interactions in our pact contract

https://jestjs.io/docs/en/watch-plugins

### Existing watch plugins

- [jest-watch-directories](https://github.com/cameronhunter/jest-watch-directories/tree/master/packages/jest-watch-directories) Select directories to test.
- [jest-watch-exec](https://github.com/unional/jest-watch-exec) Execute scripts during the watch cycle.
- [jest-watch-lerna-packages](https://github.com/cameronhunter/jest-watch-directories/blob/master/packages/jest-watch-lerna-packages) Select Lerna packages to test.
- [jest-watch-master](https://github.com/rickhanlonii/jest-watch-master) Check changes since master.
- [jest-watch-repeat](https://github.com/unional/jest-watch-repeat) Repeat test runs multiple times.
- [jest-watch-select-projects](https://github.com/rogeliog/jest-watch-select-projects) Select which Jest projects to run.
- [jest-watch-suspend](https://github.com/unional/jest-watch-suspend) Suspend watch mode so that your changes would not trigger test runs.
- [jest-watch-toggle-config](https://github.com/jest-community/jest-watch-toggle-config) Toggle boolean settings (e.g. verbosity, test coverage).
- [jest-watch-typeahead](https://github.com/jest-community/jest-watch-typeahead) Filter your tests by file name or test name.
- [jest-watch-yarn-workspaces](https://github.com/cameronhunter/jest-watch-directories/tree/master/packages/jest-watch-yarn-workspaces) Select Yarn workspaces to test.
- [node-recorder](https://github.com/ericclemmons/node-recorder/#using-jest) Toggle recording modes for `node-recorder`.
