### PR TITLE
chore(docs): fix typos on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pactWith({ consumer: 'MyConsumer', provider: 'MyProvider' }, provider => {
 
 We also include a wrapper for Pact-JS V3.
 
-**Note: The API is NOT finalized. Feedback welcome**
+**Note: The API is NOT finalised. Feedback welcome**
 
 If you have thoughts or feedback about the DSL, please let us know via slack or open issue.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pactWith({ consumer: 'MyConsumer', provider: 'MyProvider' }, provider => {
     // down the provider for you.
     beforeEach(() => // note the implicit return.
                      // addInteraction returns a promise.
-                     // If you don't want to implict return,
+                     // If you don't want to implicitly return,
                      // you will need to `await` the result
       provider.addInteraction({
         state: "Server is healthy",
@@ -96,7 +96,7 @@ pactWith({ consumer: 'MyConsumer', provider: 'MyProvider' }, provider => {
     //
     // Although Pact will ensure that the provider
     // returned the expected object, you need to test that
-    // your code recieves the right object.
+    // your code receives the right object.
     //
     // This is often the same as the object that was
     // in the network response, but (as illustrated
@@ -112,7 +112,7 @@ pactWith({ consumer: 'MyConsumer', provider: 'MyProvider' }, provider => {
 
 We also include a wrapper for Pact-JS V3.
 
-**Note: The API is NOT finalised. Feedback welcome**
+**Note: The API is NOT finalized. Feedback welcome**
 
 If you have thoughts or feedback about the DSL, please let us know via slack or open issue.
 
@@ -274,11 +274,11 @@ Jest-Pact sets some helpful default PactOptions for you. You can override any of
 Most of the time you won't need to change these.
 
 A common use case for `log` is to change only the filename or the path for
-logging. To help with this, Jest-Pact provides convienience options `logDir`
+logging. To help with this, Jest-Pact provides convenience options `logDir`
 and `logFileName`. These allow you to set the path or the filename
 independently. In case you're wondering, if you specify `log`, `logDir` and
-`logFileName`, the convienience options are ignored and `log` takes
-precidence.
+`logFileName`, the convenience options are ignored and `log` takes
+precedence.
 
 ### Jest Watch Mode
 


### PR DESCRIPTION
This commit fix some typos on the README file

<!-- Thank you for making a pull request! -->

<!-- jest-pact is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `npm run dist` all pass on my machine
  - all test passed, but one error not doc related was found
 
```bash
Test Suites: 7 passed, 7 total
Tests:       22 skipped, 18 passed, 40 total
Snapshots:   0 total
Time:        4.257 s
Ran all test suites.

> jest-pact@0.10.2 build
> rimraf dist && tsc --project tsconfig.dist.json

node_modules/@pact-foundation/pact-core/src/types.d.ts:1:8 - error TS1259: Module '"/home/ltsuda/developer/jest-pact/node_modules/@types/needle/index"' can only be default-imported using the 'esModuleInterop' flag

1 import needle from 'needle';
         ~~~~~~

  node_modules/@types/needle/index.d.ts:353:1
    353 export = needle;
        ~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 1 error in node_modules/@pact-foundation/pact-core/src/types.d.ts:1
```
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

<!-- _Please describe what this PR is for, or link the issue that this PR fixes_ -->

<!-- _You may add as much or as little context as you like here, whatever you think is right_ -->

<!-- _Thanks again!_ -->
