### PR TITLE
chore(docs): fix Pact-JS example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ pactWith({ consumer: 'MyConsumer', provider: 'MyProvider' }, provider => {
         expect(health).toEqual('up');
       }));
   });
+});
 ```
 
 ## Usage - Pact-JS V3


### PR DESCRIPTION
### Checklist

- [x] `npm run dist` all pass on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

This PR fixes a syntax error on Pact V2 README example by adding the missing closing `});` to a function. 

