### PR TITLE
chore(deps): Update typescript to 4.9.5

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
-        os: [macos-12, macos-latest]
+        node-version: [18.x, 20.x, 22.x]
+        os: [macos-13, macos-latest]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: scripts/ci/build-and-test.sh
@@ -27,22 +27,20 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.node-version }}-macos
+          flag-name: run-${{ matrix.node-version }}-${{ runner.os }}
           parallel: true
 
   build-and-test-ubuntu:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
-      # - name: Set MSVS version
-      #   run: npm config set msvs_version 2017
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: scripts/ci/build-and-test.sh
@@ -59,20 +57,15 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Fix node-gyp
-        run: |-
-          npm install --global node-gyp@latest
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-        shell: pwsh
       - run: bash scripts/ci/build-and-test.sh
         shell: bash
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - id: publish
         run: scripts/ci/release.sh

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supertest": "7.0.0",
     "ts-jest": "^29.0.3",
     "ts-node": "10.9.1",
-    "typescript": "4.6.4"
+    "typescript": "4.9.5"
   },
   "peerDependencies": {
     "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0 || ^13.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "stripInternal": true,
-    "suppressImplicitAnyIndexErrors": true
+    "stripInternal": true
   },
   "exclude": ["./node_modules/*"],
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
Fixes build errors which are causing failing pipelines by updating typescript to 4.9.5

also

- updates macos-12 runner to macos-13
- updates to run lts versions of node 18, 20, 22
- update action tags
- update to release against node 20
- remove unused tsconfig prop suppressImplicitAnyIndexErrors