### PR TITLE
feat!: change Pact to PactV2 / PactOptions to PactV2Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Features
 
-- [x] instantiates the PactOptions for you
+- [x] instantiates the PactV2Options/PactV3Options for you
 - [x] Setups Pact mock service before and after hooks so you don’t have to
 - [x] Set Jest timeout to 30 seconds preventing brittle tests in slow environments like Docker
 - [x] Sensible defaults for the pact options that make sense with Jest
@@ -20,6 +20,9 @@
 
 ## `Jest-Pact` Roadmap
 
+- [ ] Add PactV4 interface with `JestProvidedPactFnV4`
+- [ ] BREAKING CHANGE: make `JestProvidedPactFn` default to `JestProvidedPactFnV4`
+- [ ] BREAKING CHANGE: rename `JestProvidedPactFn` to `JestProvidedPactFnV2`
 - [ ] Ensure that jest-pact plays well with jest's default of watch-mode (This has been mothballed, please see this [draft pr](https://github.com/pact-foundation/jest-pact/pull/53) for details. Contributions welcome!
 - [ ] Ensure that pact failures print nice diffs (at the moment you have to go digging in the log files)
 - [ ] Add a setup hook for clearing out log and pact files
@@ -232,14 +235,16 @@ Jest-Pact has two primary functions:
 
 Additionally, `pactWith.only / fpactWith`, `pactWith.skip / xpactWith`, `messagePactWith.only / fmessagePactWith` and `messagePactWith.skip / xmessagePactWith` behave as you would expect from Jest.
 
-There are two types exported:
+There are two types exported (depending on whether you are using the V2 or V3 Pact interface):
 
-- `JestProvidedPactFn`: This is the type of the second argument to `pactWith`, ie: `(provider: Pact) => void`
-- `JestPactOptions`: An extended version of `PactOptions` that has some additional convienience options (see below).
+- `JestProvidedPactFn`: This is the type of the second argument to `pactWith`, ie: `(provider: PactV2) => void`
+- `JestPactOptions`: An extended version of `PactV2Options` that has some additional convenience options (see below).
+- `JestProvidedPactFnV3`: This is the type of the second argument to `pactWith`, ie: `(provider: PactV3) => void`
+- `JestPactOptionsV3`: An extended version of `PactV3Options` that has some additional convenience options (see below).
 
 ## Configuration
 
-You can use all the usual `PactOptions` from pact-js, plus a timeout for
+You can use all the usual `PactV2Options`/`PactV3Options` from pact-js, plus a timeout for
 telling jest to wait a bit longer for pact to start and run.
 
 ```ts
@@ -257,14 +262,14 @@ interface ExtraOptions {
   logFileName?: string; // filename for the log file
 }
 
-type JestPactOptions = PactOptions & ExtraOptions;
+type JestPactOptions = PactV2Options & ExtraOptions;
 
 type JestMessageConsumerOptions = MessageConsumerOptions & ExtraOptions;
 ```
 
 ### Defaults
 
-Jest-Pact sets some helpful default PactOptions for you. You can override any of these by explicitly setting corresponding option. Here are the defaults:
+Jest-Pact sets some helpful default `PactV2Options`/`PactV3Options` for you. You can override any of these by explicitly setting corresponding option. Here are the defaults:
 
 - `log` is set so that log files are written to `/pact/logs`, and named `<consumer>-<provider>-mockserver-interaction.log`. If you provided an explicit `port`, then the log file name is `<consumer>-<provider>-mockserver-interaction-port-<portNumber>.log`
 - `dir` is set so that pact files are written to `/pact/pacts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-pact",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "a pact adaptor for jest",
   "main": "dist/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/pact-foundation/jest-pact.git"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "author": "YOU54F",
   "contributors": [
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.2.2",
-    "@pact-foundation/pact": "^15.0.0",
+    "@pact-foundation/pact": "^16.0.0",
     "@pact-foundation/pact-js-prettier-config": "^1.0.0",
     "@tsconfig/node14": "^14.0.0",
     "@types/jest": "^30.0.0",
@@ -72,7 +72,7 @@
     "typescript": "5.9.2"
   },
   "peerDependencies": {
-    "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+    "@pact-foundation/pact": "^16.0.0" ,
     "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0"
   },
   "lint-staged": {

--- a/src/internal/scaffold.ts
+++ b/src/internal/scaffold.ts
@@ -1,7 +1,7 @@
-import { MessageConsumerOptions, PactOptions } from '@pact-foundation/pact';
+import { MessageConsumerOptions, PactV2Options } from '@pact-foundation/pact';
 import { ConsumerOptions, WrapperFn, WrapperWithOnlyAndSkip } from './types';
 
-const describeString = (options: PactOptions | MessageConsumerOptions) =>
+const describeString = (options: PactV2Options | MessageConsumerOptions) =>
   `Pact between ${options.consumer} and ${options.provider}`;
 
 const describePactWith = <

--- a/src/pactWith.ts
+++ b/src/pactWith.ts
@@ -1,4 +1,4 @@
-import { Pact } from '@pact-foundation/pact';
+import { PactV2 } from '@pact-foundation/pact';
 import { applyPactOptionDefaults } from './internal/config';
 import { WrapperFn } from './internal/types';
 import { withTimeout } from './internal/withTimeout';
@@ -6,8 +6,8 @@ import { withTimeout } from './internal/withTimeout';
 import { extendPactWith } from './internal/scaffold';
 import { JestPactOptions, JestProvidedPactFn } from './types';
 
-const setupProvider = (options: JestPactOptions): Pact => {
-  const pactMock: Pact = new Pact(options);
+const setupProvider = (options: JestPactOptions): PactV2 => {
+  const pactMock: PactV2 = new PactV2(options);
 
   beforeAll(() => pactMock.setup());
   afterAll(() => pactMock.finalize());
@@ -17,7 +17,7 @@ const setupProvider = (options: JestPactOptions): Pact => {
 };
 
 // This should be moved to pact-js, probably
-export const getProviderBaseUrl = (provider: Pact): string =>
+export const getProviderBaseUrl = (provider: PactV2): string =>
   provider.mockService
     ? provider.mockService.baseUrl
     : `http://${provider.opts.host}:${provider.opts.port}`;

--- a/src/test/fpactwith.test.ts
+++ b/src/test/fpactwith.test.ts
@@ -1,8 +1,8 @@
-import { InteractionObject, Pact } from '@pact-foundation/pact';
+import { InteractionObject, PactV2 } from '@pact-foundation/pact';
 import supertest = require('supertest');
 import { fpactWith } from '../index';
 
-const getClient = (provider: Pact) => supertest(provider.mockService.baseUrl);
+const getClient = (provider: PactV2) => supertest(provider.mockService.baseUrl);
 
 const postValidRequest: InteractionObject = {
   state: 'A pet 1845563262948980200 exists',
@@ -20,7 +20,7 @@ const postValidRequest: InteractionObject = {
 describe('fpactwith', () => {
   fpactWith(
     { consumer: 'MyConsumer', provider: 'NoProvider' },
-    (provider: Pact) => {
+    (provider: PactV2) => {
       beforeEach(() => provider.addInteraction(postValidRequest));
 
       it('should only run this test', () =>

--- a/src/test/messagePactWith.test.ts
+++ b/src/test/messagePactWith.test.ts
@@ -1,5 +1,5 @@
 import {
-  Matchers,
+  MatchersV2,
   MessageConsumerPact,
   synchronousBodyHandler,
 } from '@pact-foundation/pact';
@@ -17,7 +17,7 @@ function dogApiHandler(dog: Dog): void {
     throw new Error('missing fields');
   }
 }
-const { like, term } = Matchers;
+const { like, term } = MatchersV2;
 
 const arbitraryPact = (provider: MessageConsumerPact) => {
   describe('receive dog event', () => {

--- a/src/test/pactwith.only.test.ts
+++ b/src/test/pactwith.only.test.ts
@@ -1,8 +1,8 @@
-import { InteractionObject, Pact } from '@pact-foundation/pact';
+import { InteractionObject, PactV2 } from '@pact-foundation/pact';
 import supertest = require('supertest');
 import { pactWith } from '../index';
 
-const getClient = (provider: Pact) => supertest(provider.mockService.baseUrl);
+const getClient = (provider: PactV2) => supertest(provider.mockService.baseUrl);
 
 const postValidRequest: InteractionObject = {
   state: 'A pet 1845563262948980200 exists',
@@ -20,7 +20,7 @@ const postValidRequest: InteractionObject = {
 describe('pactwith.only', () => {
   pactWith.only(
     { consumer: 'MyConsumer', provider: 'NoProvider' },
-    (provider: Pact) => {
+    (provider: PactV2) => {
       beforeEach(() => provider.addInteraction(postValidRequest));
       it('should only run this test', () =>
         getClient(provider)

--- a/src/test/pactwith.skip.test.ts
+++ b/src/test/pactwith.skip.test.ts
@@ -1,10 +1,10 @@
-import { Pact } from '@pact-foundation/pact';
+import { PactV2 } from '@pact-foundation/pact';
 import { pactWith } from '../index';
 
 describe('pactwith.skip', () => {
   pactWith.skip(
     { consumer: 'MyConsumer', provider: 'NoOtherProvider' },
-    (_provider: Pact) => {
+    (_provider: PactV2) => {
       test('the test that should be skipped', () => {
         throw new Error('tests inside xpactWith should not run');
       });

--- a/src/test/pactwith.test.ts
+++ b/src/test/pactwith.test.ts
@@ -1,8 +1,8 @@
-import { InteractionObject, Pact } from '@pact-foundation/pact';
+import { InteractionObject, PactV2 } from '@pact-foundation/pact';
 import { agent } from 'supertest';
 import { getProviderBaseUrl, pactWith } from '../index';
 
-const getClient = (provider: Pact) =>
+const getClient = (provider: PactV2) =>
   agent(provider.mockService.baseUrl);
 const pactPort = 5001;
 
@@ -21,7 +21,7 @@ const postValidRequest: InteractionObject = {
 
 pactWith(
   { consumer: 'MyConsumer', provider: 'pactWith', port: pactPort },
-  (provider: Pact) => {
+  (provider: PactV2) => {
     describe('pact integration', () => {
       beforeEach(() => provider.addInteraction(postValidRequest));
 
@@ -59,7 +59,7 @@ pactWith(
 
 pactWith(
   { consumer: 'MyConsumer', provider: 'pactWith2' },
-  (provider: Pact) => {
+  (provider: PactV2) => {
     describe('pact integration 2', () => {
       beforeEach(() => provider.addInteraction(postValidRequest));
 
@@ -95,7 +95,7 @@ pactWith(
 );
 
 describe('custom log locations', () => {
-  const arbitraryPact = (provider: Pact) => {
+  const arbitraryPact = (provider: PactV2) => {
     describe('pact test', () => {
       beforeEach(() => provider.addInteraction(postValidRequest));
 
@@ -115,7 +115,7 @@ describe('custom log locations', () => {
           provider: 'pactWith2',
           logDir: 'pact/log/custom',
         },
-        (provider: Pact) => {
+        (provider: PactV2) => {
           arbitraryPact(provider);
         }
       );
@@ -128,7 +128,7 @@ describe('custom log locations', () => {
           logDir: 'pact/log/custom',
           logFileName: 'someLog.txt',
         },
-        (provider: Pact) => {
+        (provider: PactV2) => {
           arbitraryPact(provider);
         }
       );
@@ -141,7 +141,7 @@ describe('custom log locations', () => {
         provider: 'pactWith2',
         logFileName: 'someOtherLog.txt',
       },
-      (provider: Pact) => {
+      (provider: PactV2) => {
         arbitraryPact(provider);
       }
     );

--- a/src/test/xpactwith.test.ts
+++ b/src/test/xpactwith.test.ts
@@ -1,10 +1,10 @@
-import { Pact } from '@pact-foundation/pact';
+import { PactV2 } from '@pact-foundation/pact';
 import { xpactWith } from '../index';
 
 describe('xpactwith', () => {
   xpactWith(
     { consumer: 'MyConsumer', provider: 'NoOtherProvider' },
-    (_provider: Pact) => {
+    (_provider: PactV2) => {
       test('the test that should be skipped', () => {
         throw new Error('tests inside xpactWith should not run');
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import {
   MessageConsumerPact,
-  Pact,
+  PactV2,
   MessageConsumerOptions,
-  PactOptions,
+  PactV2Options,
 } from '@pact-foundation/pact';
 import { WrapperWithOnlyAndSkip } from './internal/types';
 
@@ -12,11 +12,11 @@ interface ExtraOptions {
   logFileName?: string;
 }
 
-export type JestPactOptions = PactOptions & ExtraOptions;
+export type JestPactOptions = PactV2Options & ExtraOptions;
 
 export type JestMessageConsumerOptions = MessageConsumerOptions & ExtraOptions;
 
-export type JestProvidedPactFn = (provider: Pact) => void;
+export type JestProvidedPactFn = (provider: PactV2) => void;
 
 export type JestProvidedMessagePactFn = (
   messagePact: MessageConsumerPact


### PR DESCRIPTION
Update to pact-js v16, which turns `Pact` default constructor, to be that of `PactV4`

Therefore update to use 

- `PactV2`
- `PactV2Options`
- `MatchersV2`

No changes to v3 interface

locally tested with locally published version of pact-js v16